### PR TITLE
feat: export normalizeDID function from JWT.js

### DIFF
--- a/src/JWT.js
+++ b/src/JWT.js
@@ -27,7 +27,7 @@ function isDIDOrMNID (mnidOrDid) {
   return mnidOrDid && (mnidOrDid.match(/^did:/) || isMNID(mnidOrDid))
 }
 
-function normalizeDID (mnidOrDid) {
+export function normalizeDID (mnidOrDid) {
   if (mnidOrDid.match(/^did:/)) return mnidOrDid
   if (isMNID(mnidOrDid)) return `did:uport:${mnidOrDid}`
   throw new Error(`Not a valid DID '${mnidOrDid}'`)


### PR DESCRIPTION
This is recommended solution for coercing legacy MNID addresses in JWTs to DIDs.  
We can export the function to make migration easier for integrators

To avoid polluting the exports from this library, we can then pass it through as an export of the minor release of `uport-credentials`
```javascript
// in credentials/index.js
import { normalizeDID } from 'did-jwt/lib/JWT'
// ...
export {Credentials, SimpleSigner, Contract, ContractFactory, JWT, normalizeDID } 
```

In particular this will help the TI&M team deal with legacy credentials