### PR TITLE
feat: Enable JWT creation without timestamps

### DIFF
--- a/src/JWT.js
+++ b/src/JWT.js
@@ -72,18 +72,23 @@ export function decodeJWT (jwt) {
 *  @param    {String}            options.issuer      The DID of the issuer (signer) of JWT
 *  @param    {String}            options.alg         The JWT signing algorithm to use. Supports: [ES256K, ES256K-R, Ed25519], Defaults to: ES256K
 *  @param    {SimpleSigner}      options.signer      a signer, reference our SimpleSigner.js
+*  @param    {Number}            options.expiresIn   Number of seconds the JWT will be valid for
+*  @param    {Boolean}           options.noTimestamp don't add a timestamp if true
 *  @return   {Promise<Object, Error>}               a promise which resolves with a signed JSON Web Token or rejects with an error
 */
-export async function createJWT (payload, { issuer, signer, alg, expiresIn }) {
+export async function createJWT (payload, { issuer, signer, alg, expiresIn, noTimestamp }) {
   if (!signer) throw new Error('No Signer functionality has been configured')
   if (!issuer) throw new Error('No issuing DID has been configured')
   const header = { ...JOSE_HEADER, alg: alg || defaultAlg }
-  const timestamps = { iat: Math.floor(Date.now() / 1000) }
-  if (expiresIn) {
-    if (typeof expiresIn === 'number') {
-      timestamps.exp = timestamps.iat + Math.floor(expiresIn)
-    } else {
-      throw new Error('JWT expiresIn is not a number')
+  const timestamps = {}
+  if (!noTimestamp) {
+    timestamps.iat = Math.floor(Date.now() / 1000)
+    if (expiresIn) {
+      if (typeof expiresIn === 'number') {
+        timestamps.exp = timestamps.iat + Math.floor(expiresIn)
+      } else {
+        throw new Error('JWT expiresIn is not a number')
+      }
     }
   }
   const signingInput = [encodeSection(header),

--- a/src/__tests__/JWT-test.js
+++ b/src/__tests__/JWT-test.js
@@ -71,6 +71,12 @@ describe('createJWT()', () => {
       })
     })
 
+    it('creates a JWT without timestamps', () => {
+      return createJWT({ requested: ['name', 'phone'] }, { issuer: did, signer, noTimestamp: true }).then((jwt) => {
+        return expect(decodeJWT(jwt)).toMatchSnapshot()
+      })
+    })
+
     it('creates a JWT with correct legacy format', () => {
       return createJWT({ requested: ['name', 'phone'] }, { issuer: mnid, signer }).then((jwt) => {
         return expect(decodeJWT(jwt)).toMatchSnapshot()

--- a/src/__tests__/__snapshots__/JWT-test.js.snap
+++ b/src/__tests__/__snapshots__/JWT-test.js.snap
@@ -38,6 +38,24 @@ Object {
 }
 `;
 
+exports[`createJWT() ES256K creates a JWT without timestamps 1`] = `
+Object {
+  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJyZXF1ZXN0ZWQiOlsibmFtZSIsInBob25lIl0sImlzcyI6ImRpZDp1cG9ydDoyblF0aVFHNkNnbTFHWVRCYWFLQWdyNzZ1WTdpU2V4VWtxWCJ9",
+  "header": Object {
+    "alg": "ES256K",
+    "typ": "JWT",
+  },
+  "payload": Object {
+    "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
+    "requested": Array [
+      "name",
+      "phone",
+    ],
+  },
+  "signature": "uelZAX_aF8rT7uu-6La9CTKL7Po_zoPTC76cbJXcn7HZuXVLU69d8SwdS-C0FjevFnWe1MPb0zLRjWGJgaBM7w",
+}
+`;
+
 exports[`createJWT() Ed25519 creates a JWT with correct format 1`] = `
 Object {
   "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZDI1NTE5In0.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOm5hY2w6QnZyQjhpSkF6XzFqZnExbVJ4aUVLZnI5cWNuTGZxNURPR3JCZjJFUlVIVSJ9",


### PR DESCRIPTION
Need a way to create JWTs that don't contain a timestamp. This PR simply adds an option to do just that.