### PR TITLE
change iat to nbf

### DIFF
--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -43,7 +43,7 @@ interface JWTPayload {
   iss?: string
   sub?: string
   aud?: string
-  iat?: number
+  nbf?: number
   type?: string
   exp?: number
   rexp?: number
@@ -88,7 +88,7 @@ function encodeSection(data: any): string {
   return base64url.encode(JSON.stringify(data))
 }
 
-export const IAT_SKEW: number = 300
+export const NBF_SKEW: number = 300
 
 /**  @module did-jwt/JWT */
 
@@ -159,12 +159,12 @@ export async function createJWT(
   if (!issuer) throw new Error('No issuing DID has been configured')
   const header: JWTHeader = { typ: 'JWT', alg: alg || defaultAlg }
   const timestamps: Partial<JWTPayload> = {
-    iat: Math.floor(Date.now() / 1000),
+    nbf: Math.floor(Date.now() / 1000),
     exp: undefined
   }
   if (expiresIn) {
     if (typeof expiresIn === 'number') {
-      timestamps.exp = timestamps.iat + Math.floor(expiresIn)
+      timestamps.exp = timestamps.nbf + Math.floor(expiresIn)
     } else {
       throw new Error('JWT expiresIn is not a number')
     }
@@ -224,14 +224,14 @@ export async function verifyJWT(
   )
   const now: number = Math.floor(Date.now() / 1000)
   if (signer) {
-    if (payload.iat && payload.iat > now + IAT_SKEW) {
+    if (payload.nbf && payload.nbf > now + NBF_SKEW) {
       throw new Error(
-        `JWT not valid yet (issued in the future): iat: ${
-          payload.iat
+        `JWT not valid yet (issued in the future): nbf: ${
+          payload.nbf
         } > now: ${now}`
       )
     }
-    if (payload.exp && payload.exp <= now - IAT_SKEW) {
+    if (payload.exp && payload.exp <= now - NBF_SKEW) {
       throw new Error(`JWT has expired: exp: ${payload.exp} < now: ${now}`)
     }
     if (payload.aud) {

--- a/src/__tests__/JWT-test.ts
+++ b/src/__tests__/JWT-test.ts
@@ -3,7 +3,7 @@ import {
   verifyJWT,
   decodeJWT,
   resolveAuthenticator,
-  IAT_SKEW
+  NBF_SKEW
 } from '../JWT'
 import { TokenVerifier } from 'jsontokens'
 import registerResolver from 'uport-did-resolver'
@@ -111,7 +111,7 @@ describe('createJWT()', () => {
         { issuer: did, signer, expiresIn: 10000 }
       ).then(jwt => {
         const { payload } = decodeJWT(jwt)
-        return expect(payload.exp).toEqual(payload.iat + 10000)
+        return expect(payload.exp).toEqual(payload.nbf + 10000)
       })
     })
 
@@ -156,7 +156,7 @@ describe('createJWT()', () => {
         { alg, issuer: did, signer, expiresIn: 10000 }
       ).then(jwt => {
         const { payload } = decodeJWT(jwt)
-        return expect(payload.exp).toEqual(payload.iat + 10000)
+        return expect(payload.exp).toEqual(payload.nbf + 10000)
       })
     })
   })
@@ -263,8 +263,8 @@ describe('verifyJWT()', () => {
     })
   })
 
-  it('accepts a valid iat', () => {
-    return createJWT({ iat: NOW + IAT_SKEW }, { issuer: did, signer }).then(
+  it('accepts a valid nbf', () => {
+    return createJWT({ nbf: NOW + NBF_SKEW }, { issuer: did, signer }).then(
       jwt =>
         verifyJWT(jwt).then(
           ({ payload }) => expect(payload).toMatchSnapshot(),
@@ -297,13 +297,13 @@ describe('verifyJWT()', () => {
     )
   })
 
-  it('rejects an iat in the future', () => {
-    return createJWT({ iat: NOW + IAT_SKEW + 1 }, { issuer: did, signer }).then(
+  it('rejects an nbf in the future', () => {
+    return createJWT({ nbf: NOW + NBF_SKEW + 1 }, { issuer: did, signer }).then(
       jwt =>
         verifyJWT(jwt)
           .catch(error =>
             expect(error.message).toEqual(
-              'JWT not valid yet (issued in the future): iat: 1485321434 > now: 1485321133'
+              'JWT not valid yet (issued in the future): nbf: 1485321434 > now: 1485321133'
             )
           )
           .then(p => expect(p).toBeFalsy())
@@ -312,7 +312,7 @@ describe('verifyJWT()', () => {
 
   it('accepts a valid exp', () => {
     return createJWT(
-      { exp: NOW - IAT_SKEW + 1 },
+      { exp: NOW - NBF_SKEW + 1 },
       { issuer: did, signer, expiresIn: 1 }
     ).then(jwt =>
       verifyJWT(jwt).then(({ payload }) => expect(payload).toMatchSnapshot())
@@ -320,7 +320,7 @@ describe('verifyJWT()', () => {
   })
 
   it('rejects an expired JWT', () => {
-    return createJWT({ exp: NOW - IAT_SKEW - 1 }, { issuer: did, signer }).then(
+    return createJWT({ exp: NOW - NBF_SKEW - 1 }, { issuer: did, signer }).then(
       jwt =>
         verifyJWT(jwt)
           .catch(error =>

--- a/src/__tests__/__snapshots__/JWT-test.ts.snap
+++ b/src/__tests__/__snapshots__/JWT-test.ts.snap
@@ -2,113 +2,113 @@
 
 exports[`createJWT() ES256K creates a JWT with correct format 1`] = `
 Object {
-  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0",
+  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJuYmYiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0",
   "header": Object {
     "alg": "ES256K",
     "typ": "JWT",
   },
   "payload": Object {
-    "iat": 1485321133,
     "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
+    "nbf": 1485321133,
     "requested": Array [
       "name",
       "phone",
     ],
   },
-  "signature": "4zZKylwG3_1WPPd0HEpeOt1uUplyXhIGQ7G26wx0T1fnwovYcXQUA-FY3Cp13iA0XwMT8kIlxwsuMFCYMdw1sw",
+  "signature": "a0u5aiRRsxTj0-bVN_pfCl95izb2bDuCsMiODbwH_wrFBH6IcLCQRclByepu0Yu__0CWyw-TQfYuxxdx-wExYw",
 }
 `;
 
 exports[`createJWT() ES256K creates a JWT with correct legacy format 1`] = `
 Object {
-  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiMm5RdGlRRzZDZ20xR1lUQmFhS0Fncjc2dVk3aVNleFVrcVgifQ",
+  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJuYmYiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiMm5RdGlRRzZDZ20xR1lUQmFhS0Fncjc2dVk3aVNleFVrcVgifQ",
   "header": Object {
     "alg": "ES256K",
     "typ": "JWT",
   },
   "payload": Object {
-    "iat": 1485321133,
     "iss": "2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
+    "nbf": 1485321133,
     "requested": Array [
       "name",
       "phone",
     ],
   },
-  "signature": "D1Tx-R9g-pyGAb4C486fx_1Scwf74JcoUC2xYRJ6cZFW9zwBs_NZEZg3bptrMfmNRao_2A2cbCncRKPpV7TycQ",
+  "signature": "YPk7tICPNhJwm251UAqLR9iskfKKVGloiAks1ndtdZv2SzRk2X9jN2LOxusJQUNoLlH1TkP0yiJb2nU4Rqrjag",
 }
 `;
 
 exports[`createJWT() Ed25519 creates a JWT with correct format 1`] = `
 Object {
-  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZDI1NTE5In0.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOm5hY2w6QnZyQjhpSkF6XzFqZnExbVJ4aUVLZnI5cWNuTGZxNURPR3JCZjJFUlVIVSJ9",
+  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZDI1NTE5In0.eyJuYmYiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOm5hY2w6QnZyQjhpSkF6XzFqZnExbVJ4aUVLZnI5cWNuTGZxNURPR3JCZjJFUlVIVSJ9",
   "header": Object {
     "alg": "Ed25519",
     "typ": "JWT",
   },
   "payload": Object {
-    "iat": 1485321133,
     "iss": "did:nacl:BvrB8iJAz_1jfq1mRxiEKfr9qcnLfq5DOGrBf2ERUHU",
+    "nbf": 1485321133,
     "requested": Array [
       "name",
       "phone",
     ],
   },
-  "signature": "ZoPf01SxW2n5zngunI942FpviEMP6jBZZb9NJ27M_K7AcmjPeeLH8bm2lv0INmJ2u98JVSzELF8YLWQvPYB1Bw",
+  "signature": "TVkTb7Copwq40dj9a8iorOi0yk_akAAW0VcsUk-XpzxGJiWMas8nXDwnxUvyPBSQLNGHu3teI0HSRBbzAiZAAg",
 }
 `;
 
 exports[`verifyJWT() accepts a valid MNID audience 1`] = `
 Object {
   "aud": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqY",
-  "iat": 1485321133,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
+  "nbf": 1485321133,
 }
 `;
 
 exports[`verifyJWT() accepts a valid audience 1`] = `
 Object {
   "aud": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqY",
-  "iat": 1485321133,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
+  "nbf": 1485321133,
 }
 `;
 
 exports[`verifyJWT() accepts a valid audience using callback_url 1`] = `
 Object {
   "aud": "http://pututu.uport.me/unique",
-  "iat": 1485321133,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
+  "nbf": 1485321133,
 }
 `;
 
 exports[`verifyJWT() accepts a valid exp 1`] = `
 Object {
   "exp": 1485320834,
-  "iat": 1485321133,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
+  "nbf": 1485321133,
 }
 `;
 
-exports[`verifyJWT() accepts a valid iat 1`] = `
+exports[`verifyJWT() accepts a valid nbf 1`] = `
 Object {
-  "iat": 1485321433,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
+  "nbf": 1485321433,
 }
 `;
 
 exports[`verifyJWT() handles ES256K-R algorithm 1`] = `
 Object {
   "hello": "world",
-  "iat": 1485321133,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
+  "nbf": 1485321133,
 }
 `;
 
 exports[`verifyJWT() handles ES256K-R algorithm with ethereum address 1`] = `
 Object {
   "hello": "world",
-  "iat": 1485321133,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqY",
+  "nbf": 1485321133,
 }
 `;
 


### PR DESCRIPTION
`did-jwt` currently sets the `iat` attribute to the current timestamp in seconds.  The W3C VC JWT spec has been changed to use the `nbf` attribute instead.  This PR changes all occurrences of `iat` to `nbf` when creating and verifying JWTs.

Tests have been updated to check for the presence of `nbf`.