### PR TITLE
[WIP] potentially breaking changes needed for W3C VC support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "did-jwt",
-  "version": "0.2.0",
+  "version": "1.0.0-dev.0",
   "description": "Library for Signing and Verifying JWTs compatible uPort and DID standards",
   "main": "lib/index.js",
   "source": "src/index.ts",

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -179,6 +179,17 @@ export async function createJWT(
   return [signingInput, signature].join('.')
 }
 
+export function createUnsignedJWT(payload: object): string {
+  return [
+    encodeSection({
+      type: 'JWT',
+      alg: 'none,'
+    }),
+    encodeSection(payload),
+    ''
+  ].join('.')
+}
+
 /**
  *  Verifies given JWT. If the JWT is valid, the promise returns an object including the JWT, the payload of the JWT,
  *  and the did doc of the issuer of the JWT.

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -156,7 +156,6 @@ export async function createJWT(
   { issuer, signer, alg, expiresIn }: JWTOptions
 ): Promise<string> {
   if (!signer) throw new Error('No Signer functionality has been configured')
-  if (!issuer) throw new Error('No issuing DID has been configured')
   const header: JWTHeader = { typ: 'JWT', alg: alg || defaultAlg }
   const timestamps: Partial<JWTPayload> = {
     nbf: Math.floor(Date.now() / 1000),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import SimpleSigner from './SimpleSigner'
 import NaclSigner from './NaclSigner'
-import { verifyJWT, createJWT, decodeJWT, Signer } from './JWT'
+import { verifyJWT, createJWT, decodeJWT, Signer, createUnsignedJWT } from './JWT'
 import { toEthereumAddress } from './Digest'
 
 export {
@@ -8,6 +8,7 @@ export {
   NaclSigner,
   verifyJWT,
   createJWT,
+  createUnsignedJWT,
   decodeJWT,
   toEthereumAddress,
   Signer


### PR DESCRIPTION
In this PR:
- allow creation of a signed JWT without specifying issuer did
- allow creation of unsigned did

Other potential changes:
- remove logic for checking `aud` from `verifyJWT`
- API of `createJWT`
- automatically populated attributes (`iat`, `nbf`, etc)?