### PR TITLE
feat: verifyJWT against nbf if present but use iat if not

### DIFF
--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -233,7 +233,7 @@ export async function verifyJWT(
     } else if (payload.iat && payload.iat > nowSkewed) {
       throw new Error(`JWT not valid yet (issued in the future) iat: ${payload.iat}`)
     }
-    if (payload.exp && payload.exp <= nowSkewed) {
+    if (payload.exp && payload.exp <= now - NBF_SKEW) {
       throw new Error(`JWT has expired: exp: ${payload.exp} < now: ${now}`)
     }
     if (payload.aud) {

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -225,14 +225,15 @@ export async function verifyJWT(
   )
   const now: number = Math.floor(Date.now() / 1000)
   if (signer) {
-    if (payload.nbf && payload.nbf > now + NBF_SKEW) {
-      throw new Error(
-        `JWT not valid yet (issued in the future): nbf: ${
-          payload.nbf
-        } > now: ${now}`
-      )
+    const nowSkewed = now + NBF_SKEW
+    if (payload.nbf) {
+      if (payload.nbf > nowSkewed) {
+        throw new Error(`JWT not valid before nbf: ${payload.nbf}`)
+      }
+    } else if (payload.iat && payload.iat > nowSkewed) {
+      throw new Error(`JWT not valid yet (issued in the future) iat: ${payload.iat}`)
     }
-    if (payload.exp && payload.exp <= now - NBF_SKEW) {
+    if (payload.exp && payload.exp <= nowSkewed) {
       throw new Error(`JWT has expired: exp: ${payload.exp} < now: ${now}`)
     }
     if (payload.aud) {

--- a/src/__tests__/JWT-test.ts
+++ b/src/__tests__/JWT-test.ts
@@ -301,52 +301,38 @@ describe('verifyJWT()', () => {
 
   describe('validFrom timestamp', () => {
     it('passes when nbf is in the past', async () => {
-      const jwt = await createJWT(
-        { nbf: PAST },
-        { issuer: did, signer }
-      )
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsIm5iZiI6MTQ4NTI2MTEzMywiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0.btzVz7fZsoSEDa7JyWo3cYWL63pkWTKTz8OUzepIesfSFeBozUjX2oq1xOJ2OyzuinnLGwtSqY303VoyALrafA'
       expect(verifyJWT(jwt)).resolves.not.toThrow()
     })
     it('passes when nbf is in the past and iat is in the future', async () => {
-      const jwt = await createJWT(
-        { nbf: PAST, iat: FUTURE },
-        { issuer: did, signer }
-      )
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzODExMzMsIm5iZiI6MTQ4NTI2MTEzMywiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0.ELsPnDC_YTTkT5hxw09UCLSjWVje9mDs1n_mpvlo2Wk5VJONSy-FDAzm5TunzzCeLixU04m6dD4w6Uk3-OVkww'
       expect(verifyJWT(jwt)).resolves.not.toThrow()
     })
     it('fails when nbf is in the future', async () => {
-      const jwt = await createJWT(
-        { nbf: FUTURE },
-        { issuer: did, signer }
-      )
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsIm5iZiI6MTQ4NTM4MTEzMywiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0.rcFuhVHtie3Y09pWxBSf1dnjaVh6FFQLHh-83N-uLty3M5ADJ-jVFFkyt_Eupl8Kr735-oPGn_D1Nj9rl4s_Kw'
       expect(verifyJWT(jwt)).rejects.toThrow()
     })
     it('fails when nbf is in the future and iat is in the past', async () => {
-      const jwt = await createJWT(
-        { nbf: FUTURE, iat: PAST },
-        { issuer: did, signer }
-      )
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUyNjExMzMsIm5iZiI6MTQ4NTM4MTEzMywiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0.jiVI11IcKNOvnDrJBzojKtNAGaZbEcafcqW-wfP78g6-6RucjYPBi5qvKje35IOvITWvvpXpK48IW-17Srh02w'
       expect(verifyJWT(jwt)).rejects.toThrow()
     })
     it('passes when nbf is missing and iat is in the past', async () => {
-      const jwt = await createJWT(
-        { iat: PAST },
-        { issuer: did, signer }
-      )
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUyNjExMzMsImlzcyI6ImRpZDp1cG9ydDoyblF0aVFHNkNnbTFHWVRCYWFLQWdyNzZ1WTdpU2V4VWtxWCJ9.1VwGHDm7f9V-1Fa545uAwF9NfU3RI8yqRFW6XAHOg0FBeM7krC_rEf0PwqbKFO8MiIBELBwUhW_fT4oZsuggUA'
       expect(verifyJWT(jwt)).resolves.not.toThrow()
     })
     it('fails when nbf is missing and iat is in the future', async () => {
-      const jwt = await createJWT(
-        { iat: FUTURE },
-        { issuer: did, signer }
-      )
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzODExMzMsImlzcyI6ImRpZDp1cG9ydDoyblF0aVFHNkNnbTFHWVRCYWFLQWdyNzZ1WTdpU2V4VWtxWCJ9.jU0R8qP3aUX_3DiFt9tIONiq_P5OooFc-ypUwpqK4plGyw6WiI0FTGfZvq7pOarKrjmSojE9Sm_3ETfMpdQckg'
       expect(verifyJWT(jwt)).rejects.toThrow()
     })
     it('passes when nbf and iat are both missing', async () => {
-      const jwt = await createJWT(
-        { iat: undefined },
-        { issuer: did, signer }
-      )
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6dXBvcnQ6Mm5RdGlRRzZDZ20xR1lUQmFhS0Fncjc2dVk3aVNleFVrcVgifQ.5kGKU9ljebhTqvfVDu9MH7vGAqRH0GDTbZNGH45YmhUySgBTyI7u-MkkRit72eFvQAqBfzw6wNUbGf9FPC5AtQ'
       expect(verifyJWT(jwt)).resolves.not.toThrow()
     })
   })

--- a/src/__tests__/JWT-test.ts
+++ b/src/__tests__/JWT-test.ts
@@ -344,7 +344,7 @@ describe('verifyJWT()', () => {
     })
     it('passes when nbf and iat are both missing', async () => {
       const jwt = await createJWT(
-        {},
+        { iat: undefined },
         { issuer: did, signer }
       )
       expect(verifyJWT(jwt)).resolves.not.toThrow()
@@ -377,7 +377,7 @@ describe('verifyJWT()', () => {
 
   it('accepts a valid exp', () => {
     return createJWT(
-      { exp: NOW + 1000 },
+      { exp: NOW },
       { issuer: did, signer }
     ).then(jwt =>
       verifyJWT(jwt).then(({ payload }) => expect(payload).toBeDefined())

--- a/src/__tests__/JWT-test.ts
+++ b/src/__tests__/JWT-test.ts
@@ -20,8 +20,6 @@ registerResolver()
 registerNaclDID()
 
 const NOW = 1485321133
-const PAST = NOW - 60000
-const FUTURE = NOW + 60000
 MockDate.set(NOW * 1000 + 123)
 
 const audMnid = '2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqY'

--- a/src/__tests__/__snapshots__/JWT-test.ts.snap
+++ b/src/__tests__/__snapshots__/JWT-test.ts.snap
@@ -81,22 +81,6 @@ Object {
 }
 `;
 
-exports[`verifyJWT() accepts a valid exp 1`] = `
-Object {
-  "exp": 1485320834,
-  "iat": 1485321133,
-  "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
-}
-`;
-
-exports[`verifyJWT() accepts a valid nbf 1`] = `
-Object {
-  "iat": 1485321133,
-  "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
-  "nbf": 1485321433,
-}
-`;
-
 exports[`verifyJWT() handles ES256K-R algorithm 1`] = `
 Object {
   "hello": "world",


### PR DESCRIPTION
This PR adds support for checking the current time against the `nbf` field when verifying a JWT.  It prioritizes the presence of `nbf` in order to comply with W3C VC standards, but falls back to `iat` when it is absent in order to maintain support for legacy format JWTs.

This completes [#167881436](https://www.pivotaltracker.com/n/projects/2198688/stories/167881436) on pivotal

Test scenarios have been added to validate the behavior for all combinations of `nbf` and `iat` fields being part of the JWT or not.