### PR TITLE
release: add support for nbf attribute

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,13 +26,48 @@ jobs:
           name: code-coverage
           command: bash <(curl -s https://codecov.io/bash)
 
+      - run:
+          name: commitlint
+          command: |
+            echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
+            npm install @commitlint/cli @commitlint/config-conventional
+            npx semantic-commitlint -- --ci
+
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - ./node_modules
+
+  release:
+    working_directory: ~/did-jwt
+    docker:
+      - image: circleci/node:8
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "51:b0:64:c7:62:ec:87:ac:cd:56:96:15:22:2e:e3:eb"
+      - checkout
+      - run:
+          name: release
+          command: |
+            export GITHUB_TOKEN=$GITHUB_TOKEN
+            git config user.email "devops@uport.me"
+            git config user.name "uport-eng"
+            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+            npx semantic-release@beta --debug
 
 workflows:
   version: 2
   build-and-deploy:
     jobs:
       - build
+      - release:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+                - beta
+                - alpha
+                - next

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,14 @@
+{
+    "branches": [
+        "master",
+        "next",
+        {
+            "prerelease": true,
+            "name": "beta"
+        },
+        {
+            "prerelease": true,
+            "name": "alpha"
+        }
+    ]
+}

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -43,6 +43,7 @@ interface JWTPayload {
   iss?: string
   sub?: string
   aud?: string
+  iat?: number
   nbf?: number
   type?: string
   exp?: number
@@ -152,19 +153,19 @@ export function decodeJWT(jwt: string): JWTDecoded {
  */
 // export async function createJWT(payload, { issuer, signer, alg, expiresIn }) {
 export async function createJWT(
-  payload: object,
+  payload: any,
   { issuer, signer, alg, expiresIn }: JWTOptions
 ): Promise<string> {
   if (!signer) throw new Error('No Signer functionality has been configured')
   if (!issuer) throw new Error('No issuing DID has been configured')
   const header: JWTHeader = { typ: 'JWT', alg: alg || defaultAlg }
   const timestamps: Partial<JWTPayload> = {
-    nbf: Math.floor(Date.now() / 1000),
+    iat: Math.floor(Date.now() / 1000),
     exp: undefined
   }
-  if (expiresIn) {
+  if (expiresIn && payload.nbf) {
     if (typeof expiresIn === 'number') {
-      timestamps.exp = timestamps.nbf + Math.floor(expiresIn)
+      timestamps.exp = payload.nbf + Math.floor(expiresIn)
     } else {
       throw new Error('JWT expiresIn is not a number')
     }

--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -225,12 +225,13 @@ export async function verifyJWT(
   )
   const now: number = Math.floor(Date.now() / 1000)
   if (signer) {
-    if (payload.nbf && payload.nbf > now + NBF_SKEW) {
-      throw new Error(
-        `JWT not valid yet (issued in the future): nbf: ${
-          payload.nbf
-        } > now: ${now}`
-      )
+    const nowSkewed = now + NBF_SKEW
+    if (payload.nbf) {
+      if (payload.nbf > nowSkewed) {
+        throw new Error(`JWT not valid before nbf: ${payload.nbf}`)
+      }
+    } else if (payload.iat && payload.iat > nowSkewed) {
+      throw new Error(`JWT not valid yet (issued in the future) iat: ${payload.iat}`)
     }
     if (payload.exp && payload.exp <= now - NBF_SKEW) {
       throw new Error(`JWT has expired: exp: ${payload.exp} < now: ${now}`)

--- a/src/__tests__/JWT-test.ts
+++ b/src/__tests__/JWT-test.ts
@@ -297,14 +297,42 @@ describe('verifyJWT()', () => {
     })
   })
 
-  it('accepts a valid nbf', () => {
-    return createJWT({ nbf: NOW + NBF_SKEW }, { issuer: did, signer }).then(
-      jwt =>
-        verifyJWT(jwt).then(
-          ({ payload }) => expect(payload).toMatchSnapshot(),
-          error => expect(error).toBeNull()
-        )
-    )
+  describe('validFrom timestamp', () => {
+    it('passes when nbf is in the past', async () => {
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsIm5iZiI6MTQ4NTI2MTEzMywiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0.btzVz7fZsoSEDa7JyWo3cYWL63pkWTKTz8OUzepIesfSFeBozUjX2oq1xOJ2OyzuinnLGwtSqY303VoyALrafA'
+      expect(verifyJWT(jwt)).resolves.not.toThrow()
+    })
+    it('passes when nbf is in the past and iat is in the future', async () => {
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzODExMzMsIm5iZiI6MTQ4NTI2MTEzMywiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0.ELsPnDC_YTTkT5hxw09UCLSjWVje9mDs1n_mpvlo2Wk5VJONSy-FDAzm5TunzzCeLixU04m6dD4w6Uk3-OVkww'
+      expect(verifyJWT(jwt)).resolves.not.toThrow()
+    })
+    it('fails when nbf is in the future', async () => {
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsIm5iZiI6MTQ4NTM4MTEzMywiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0.rcFuhVHtie3Y09pWxBSf1dnjaVh6FFQLHh-83N-uLty3M5ADJ-jVFFkyt_Eupl8Kr735-oPGn_D1Nj9rl4s_Kw'
+      expect(verifyJWT(jwt)).rejects.toThrow()
+    })
+    it('fails when nbf is in the future and iat is in the past', async () => {
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUyNjExMzMsIm5iZiI6MTQ4NTM4MTEzMywiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0.jiVI11IcKNOvnDrJBzojKtNAGaZbEcafcqW-wfP78g6-6RucjYPBi5qvKje35IOvITWvvpXpK48IW-17Srh02w'
+      expect(verifyJWT(jwt)).rejects.toThrow()
+    })
+    it('passes when nbf is missing and iat is in the past', async () => {
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUyNjExMzMsImlzcyI6ImRpZDp1cG9ydDoyblF0aVFHNkNnbTFHWVRCYWFLQWdyNzZ1WTdpU2V4VWtxWCJ9.1VwGHDm7f9V-1Fa545uAwF9NfU3RI8yqRFW6XAHOg0FBeM7krC_rEf0PwqbKFO8MiIBELBwUhW_fT4oZsuggUA'
+      expect(verifyJWT(jwt)).resolves.not.toThrow()
+    })
+    it('fails when nbf is missing and iat is in the future', async () => {
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzODExMzMsImlzcyI6ImRpZDp1cG9ydDoyblF0aVFHNkNnbTFHWVRCYWFLQWdyNzZ1WTdpU2V4VWtxWCJ9.jU0R8qP3aUX_3DiFt9tIONiq_P5OooFc-ypUwpqK4plGyw6WiI0FTGfZvq7pOarKrjmSojE9Sm_3ETfMpdQckg'
+      expect(verifyJWT(jwt)).rejects.toThrow()
+    })
+    it('passes when nbf and iat are both missing', async () => {
+      // tslint:disable-next-line: max-line-length
+      const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6dXBvcnQ6Mm5RdGlRRzZDZ20xR1lUQmFhS0Fncjc2dVk3aVNleFVrcVgifQ.5kGKU9ljebhTqvfVDu9MH7vGAqRH0GDTbZNGH45YmhUySgBTyI7u-MkkRit72eFvQAqBfzw6wNUbGf9FPC5AtQ'
+      expect(verifyJWT(jwt)).resolves.not.toThrow()
+    })
   })
 
   it('handles ES256K-R algorithm', () => {
@@ -331,25 +359,12 @@ describe('verifyJWT()', () => {
     )
   })
 
-  it('rejects an nbf in the future', () => {
-    return createJWT({ nbf: NOW + NBF_SKEW + 1 }, { issuer: did, signer }).then(
-      jwt =>
-        verifyJWT(jwt)
-          .catch(error =>
-            expect(error.message).toEqual(
-              'JWT not valid yet (issued in the future): nbf: 1485321434 > now: 1485321133'
-            )
-          )
-          .then(p => expect(p).toBeFalsy())
-    )
-  })
-
   it('accepts a valid exp', () => {
     return createJWT(
-      { exp: NOW - NBF_SKEW + 1 },
-      { issuer: did, signer, expiresIn: 1 }
+      { exp: NOW },
+      { issuer: did, signer }
     ).then(jwt =>
-      verifyJWT(jwt).then(({ payload }) => expect(payload).toMatchSnapshot())
+      verifyJWT(jwt).then(({ payload }) => expect(payload).toBeDefined())
     )
   })
 

--- a/src/__tests__/JWT-test.ts
+++ b/src/__tests__/JWT-test.ts
@@ -107,12 +107,46 @@ describe('createJWT()', () => {
 
     it('creates a JWT with expiry in 10000 seconds', () => {
       return createJWT(
-        { requested: ['name', 'phone'] },
+        { requested: ['name', 'phone'], nbf: Math.floor(new Date().getTime() / 1000) },
         { issuer: did, signer, expiresIn: 10000 }
       ).then(jwt => {
         const { payload } = decodeJWT(jwt)
         return expect(payload.exp).toEqual(payload.nbf + 10000)
       })
+    })
+
+    it('ignores expiresIn if nbf is not set', async () => {
+      const { payload } = decodeJWT(await createJWT(
+        { requested: ['name', 'phone'] },
+        { issuer: did, signer, expiresIn: 10000 }
+      ))
+      return expect(payload.exp).toBeUndefined()
+    })
+
+    it('sets iat to the current time by default', async () => {
+      const timestamp = Math.floor(Date.now() / 1000)
+      const { payload } = decodeJWT(await createJWT(
+        { requested: ['name', 'phone'] },
+        { issuer: did, signer }
+      ))
+      return expect(payload.iat).toEqual(timestamp)
+    })
+
+    it('sets iat to the value passed in payload', async () => {
+      const timestamp = 2000000
+      const { payload } = decodeJWT(await createJWT(
+        { requested: ['name', 'phone'], iat: timestamp },
+        { issuer: did, signer }
+      ))
+      return expect(payload.iat).toEqual(timestamp)
+    })
+
+    it('does not set iat if value in payload is undefined', async () => {
+      const { payload } = decodeJWT(await createJWT(
+        { requested: ['name', 'phone'], iat: undefined },
+        { issuer: did, signer }
+      ))
+      return expect(payload.iat).toBeUndefined()
     })
 
     it('throws an error if unsupported algorithm is passed in', () => {
@@ -152,7 +186,7 @@ describe('createJWT()', () => {
 
     it('creates a JWT with expiry in 10000 seconds', () => {
       return createJWT(
-        { requested: ['name', 'phone'] },
+        { requested: ['name', 'phone'], nbf: Math.floor(new Date().getTime() / 1000) },
         { alg, issuer: did, signer, expiresIn: 10000 }
       ).then(jwt => {
         const { payload } = decodeJWT(jwt)

--- a/src/__tests__/__snapshots__/JWT-test.ts.snap
+++ b/src/__tests__/__snapshots__/JWT-test.ts.snap
@@ -2,95 +2,96 @@
 
 exports[`createJWT() ES256K creates a JWT with correct format 1`] = `
 Object {
-  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJuYmYiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0",
+  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0",
   "header": Object {
     "alg": "ES256K",
     "typ": "JWT",
   },
   "payload": Object {
+    "iat": 1485321133,
     "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
-    "nbf": 1485321133,
     "requested": Array [
       "name",
       "phone",
     ],
   },
-  "signature": "a0u5aiRRsxTj0-bVN_pfCl95izb2bDuCsMiODbwH_wrFBH6IcLCQRclByepu0Yu__0CWyw-TQfYuxxdx-wExYw",
+  "signature": "4zZKylwG3_1WPPd0HEpeOt1uUplyXhIGQ7G26wx0T1fnwovYcXQUA-FY3Cp13iA0XwMT8kIlxwsuMFCYMdw1sw",
 }
 `;
 
 exports[`createJWT() ES256K creates a JWT with correct legacy format 1`] = `
 Object {
-  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJuYmYiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiMm5RdGlRRzZDZ20xR1lUQmFhS0Fncjc2dVk3aVNleFVrcVgifQ",
+  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiMm5RdGlRRzZDZ20xR1lUQmFhS0Fncjc2dVk3aVNleFVrcVgifQ",
   "header": Object {
     "alg": "ES256K",
     "typ": "JWT",
   },
   "payload": Object {
+    "iat": 1485321133,
     "iss": "2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
-    "nbf": 1485321133,
     "requested": Array [
       "name",
       "phone",
     ],
   },
-  "signature": "YPk7tICPNhJwm251UAqLR9iskfKKVGloiAks1ndtdZv2SzRk2X9jN2LOxusJQUNoLlH1TkP0yiJb2nU4Rqrjag",
+  "signature": "D1Tx-R9g-pyGAb4C486fx_1Scwf74JcoUC2xYRJ6cZFW9zwBs_NZEZg3bptrMfmNRao_2A2cbCncRKPpV7TycQ",
 }
 `;
 
 exports[`createJWT() Ed25519 creates a JWT with correct format 1`] = `
 Object {
-  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZDI1NTE5In0.eyJuYmYiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOm5hY2w6QnZyQjhpSkF6XzFqZnExbVJ4aUVLZnI5cWNuTGZxNURPR3JCZjJFUlVIVSJ9",
+  "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZDI1NTE5In0.eyJpYXQiOjE0ODUzMjExMzMsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXSwiaXNzIjoiZGlkOm5hY2w6QnZyQjhpSkF6XzFqZnExbVJ4aUVLZnI5cWNuTGZxNURPR3JCZjJFUlVIVSJ9",
   "header": Object {
     "alg": "Ed25519",
     "typ": "JWT",
   },
   "payload": Object {
+    "iat": 1485321133,
     "iss": "did:nacl:BvrB8iJAz_1jfq1mRxiEKfr9qcnLfq5DOGrBf2ERUHU",
-    "nbf": 1485321133,
     "requested": Array [
       "name",
       "phone",
     ],
   },
-  "signature": "TVkTb7Copwq40dj9a8iorOi0yk_akAAW0VcsUk-XpzxGJiWMas8nXDwnxUvyPBSQLNGHu3teI0HSRBbzAiZAAg",
+  "signature": "ZoPf01SxW2n5zngunI942FpviEMP6jBZZb9NJ27M_K7AcmjPeeLH8bm2lv0INmJ2u98JVSzELF8YLWQvPYB1Bw",
 }
 `;
 
 exports[`verifyJWT() accepts a valid MNID audience 1`] = `
 Object {
   "aud": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqY",
+  "iat": 1485321133,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
-  "nbf": 1485321133,
 }
 `;
 
 exports[`verifyJWT() accepts a valid audience 1`] = `
 Object {
   "aud": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqY",
+  "iat": 1485321133,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
-  "nbf": 1485321133,
 }
 `;
 
 exports[`verifyJWT() accepts a valid audience using callback_url 1`] = `
 Object {
   "aud": "http://pututu.uport.me/unique",
+  "iat": 1485321133,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
-  "nbf": 1485321133,
 }
 `;
 
 exports[`verifyJWT() accepts a valid exp 1`] = `
 Object {
   "exp": 1485320834,
+  "iat": 1485321133,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
-  "nbf": 1485321133,
 }
 `;
 
 exports[`verifyJWT() accepts a valid nbf 1`] = `
 Object {
+  "iat": 1485321133,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
   "nbf": 1485321433,
 }
@@ -99,16 +100,16 @@ Object {
 exports[`verifyJWT() handles ES256K-R algorithm 1`] = `
 Object {
   "hello": "world",
+  "iat": 1485321133,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
-  "nbf": 1485321133,
 }
 `;
 
 exports[`verifyJWT() handles ES256K-R algorithm with ethereum address 1`] = `
 Object {
   "hello": "world",
+  "iat": 1485321133,
   "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqY",
-  "nbf": 1485321133,
 }
 `;
 

--- a/src/__tests__/__snapshots__/JWT-test.ts.snap
+++ b/src/__tests__/__snapshots__/JWT-test.ts.snap
@@ -81,22 +81,6 @@ Object {
 }
 `;
 
-exports[`verifyJWT() accepts a valid exp 1`] = `
-Object {
-  "exp": 1485320834,
-  "iat": 1485321133,
-  "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
-}
-`;
-
-exports[`verifyJWT() accepts a valid nbf 1`] = `
-Object {
-  "iat": 1485321133,
-  "iss": "did:uport:2nQtiQG6Cgm1GYTBaaKAgr76uY7iSexUkqX",
-  "nbf": 1485321433,
-}
-`;
-
 exports[`verifyJWT() handles ES256K-R algorithm 1`] = `
 Object {
   "hello": "world",


### PR DESCRIPTION
This PR releases the changes to support using the `nbf` field to represent the beginning of the JWTs validity period.  JWTs created before this change that use `iat` will still be supported as well.