### PR TITLE
feat: add getter and setter for did resolver

### DIFF
--- a/src/JWT.ts
+++ b/src/JWT.ts
@@ -86,10 +86,18 @@ const SUPPORTED_PUBLIC_KEY_TYPES: PublicKeyTypes = {
 
 const defaultAlg = 'ES256K'
 
-export const resolver = new Resolver({
+// tslint:disable-next-line: variable-name
+let _resolver = new Resolver({
   ...getEthrDidResolver(),
   ...getHttpsDidResolver()
 })
+export const getResolver = () => (_resolver)
+export const setResolver = resolver => {
+  if (!resolver.resolve || typeof resolver.resolve !== 'function') {
+    throw new Error('resolver must contain a function named resolve')
+  }
+  _resolver = resolver
+}
 
 function encodeSection(data: any): string {
   return base64url.encode(JSON.stringify(data))
@@ -302,7 +310,7 @@ export async function resolveAuthenticator(
     throw new Error(`No supported signature types for algorithm ${alg}`)
   }
   const issuer: string = normalizeDID(mnidOrDid)
-  const doc: DIDDocument = await resolver.resolve(issuer)
+  const doc: DIDDocument = await _resolver.resolve(issuer)
   if (!doc) throw new Error(`Unable to resolve DID document for ${issuer}`)
   // is there some way to have authenticationKeys be a single type?
   const authenticationKeys: boolean | string[] = auth


### PR DESCRIPTION
This PR adds two functions `getResolver()` and `setResolver()` that allow the user to override the did-resolver used by `verifyJWT()`.  By default, it will still use a did-resolver that has ethr-did and https-did resolvers configured without any customizations.

Although this implementation is different from what was previously discussed of turning did-jwt into a class and having the resolver be passed as an optional param of the constructor, I believe that using a setter instead can achieve the same effect with much fewer (and no breaking) changes.  Additionally, refactoring it to be encapsulated within a class needlessly changes the way all other functions are accessed when `verifyJWT()` is the only one that uses the resolver.

@mirceanis what do you think about this approach?