### PR TITLE
feat: require resolver to be passed as a parameter to verifyJWT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -524,7 +524,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -1316,15 +1316,6 @@
       "requires": {
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
         "babel-plugin-jest-hoist": "^24.6.0"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
       }
     },
     "babylon": {
@@ -2382,7 +2373,8 @@
     "core-js": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3699,146 +3691,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "ethjs-abi": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.1.tgz",
-      "integrity": "sha1-4KepOn6BFjqUR3utVu3lJKtt5TM=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "js-sha3": "0.5.5",
-        "number-to-bn": "1.7.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "js-sha3": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
-        }
-      }
-    },
-    "ethjs-contract": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/ethjs-contract/-/ethjs-contract-0.1.9.tgz",
-      "integrity": "sha1-HCdmiWpW1H7B1tZhgpxJzDilUgo=",
-      "requires": {
-        "ethjs-abi": "0.2.0",
-        "ethjs-filter": "0.1.5",
-        "ethjs-util": "0.1.3",
-        "js-sha3": "0.5.5"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "ethjs-abi": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.0.tgz",
-          "integrity": "sha1-0+LCIQEVIPxJm3FoIDbBT8wvWyU=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "js-sha3": "0.5.5",
-            "number-to-bn": "1.7.0"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
-        }
-      }
-    },
-    "ethjs-filter": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/ethjs-filter/-/ethjs-filter-0.1.5.tgz",
-      "integrity": "sha1-ARKvYBfCRnfjK4/esg5hlgGbdZg="
-    },
-    "ethjs-format": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/ethjs-format/-/ethjs-format-0.2.7.tgz",
-      "integrity": "sha512-uNYAi+r3/mvR3xYu2AfSXx5teP4ovy9z2FrRsblU+h2logsaIKZPi9V3bn3V7wuRcnG0HZ3QydgZuVaRo06C4Q==",
-      "requires": {
-        "bn.js": "4.11.6",
-        "ethjs-schema": "0.2.1",
-        "ethjs-util": "0.1.3",
-        "is-hex-prefixed": "1.0.0",
-        "number-to-bn": "1.7.0",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        }
-      }
-    },
-    "ethjs-provider-http": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-provider-http/-/ethjs-provider-http-0.1.6.tgz",
-      "integrity": "sha1-HsXZtL4lfvHValALIqdBmF6IlCA=",
-      "requires": {
-        "xhr2": "0.1.3"
-      }
-    },
-    "ethjs-query": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/ethjs-query/-/ethjs-query-0.3.8.tgz",
-      "integrity": "sha512-/J5JydqrOzU8O7VBOwZKUWXxHDGr46VqNjBCJgBVNNda+tv7Xc8Y2uJc6aMHHVbeN3YOQ7YRElgIc0q1CI02lQ==",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "ethjs-format": "0.2.7",
-        "ethjs-rpc": "0.2.0",
-        "promise-to-callback": "^1.0.0"
-      }
-    },
-    "ethjs-rpc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ethjs-rpc/-/ethjs-rpc-0.2.0.tgz",
-      "integrity": "sha512-RINulkNZTKnj4R/cjYYtYMnFFaBcVALzbtEJEONrrka8IeoarNB9Jbzn+2rT00Cv8y/CxAI+GgY1d0/i2iQeOg==",
-      "requires": {
-        "promise-to-callback": "^1.0.0"
-      }
-    },
-    "ethjs-schema": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ethjs-schema/-/ethjs-schema-0.2.1.tgz",
-      "integrity": "sha512-DXd8lwNrhT9sjsh/Vd2Z+4pfyGxhc0POVnLBUfwk5udtdoBzADyq+sK39dcb48+ZU+2VgtwHxtGWnLnCfmfW5g=="
-    },
-    "ethjs-util": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.3.tgz",
-      "integrity": "sha1-39XqSkANxeQhqInK9H4IGtp4u1U=",
-      "requires": {
-        "is-hex-prefixed": "1.0.0",
-        "strip-hex-prefix": "1.0.0"
-      }
-    },
-    "ethr-did-registry": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/ethr-did-registry/-/ethr-did-registry-0.0.3.tgz",
-      "integrity": "sha512-4BPvMGkxAK9vTduCq6D5b8ZqjteD2cvDIPPriXP6nnmPhWKFSxypo+AFvyQ0omJGa0cGTR+dkdI/8jiF7U/qaw=="
-    },
-    "ethr-did-resolver": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-1.0.1.tgz",
-      "integrity": "sha512-aASzVYfkD5jJEJPcQFF/oF6qcoAb8LfzTPvjIdRInfJ4c5eXGdb7T1QnH4tD0L7ezbK2RzVcAMrmqH6hQ36f8Q==",
-      "requires": {
-        "buffer": "^5.1.0",
-        "did-resolver": "1.0.0",
-        "ethjs-abi": "^0.2.1",
-        "ethjs-contract": "^0.1.9",
-        "ethjs-provider-http": "^0.1.6",
-        "ethjs-query": "^0.3.5",
-        "ethr-did-registry": "^0.0.3"
-      }
-    },
     "events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
@@ -4447,8 +4299,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4469,14 +4320,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4491,20 +4340,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4621,8 +4467,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4634,7 +4479,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4649,7 +4493,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4657,14 +4500,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4683,7 +4524,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4764,8 +4604,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4777,7 +4616,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4863,8 +4701,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4900,7 +4737,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4920,7 +4756,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4964,14 +4799,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5394,22 +5227,6 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
-    "https-did-resolver": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-did-resolver/-/https-did-resolver-1.0.0.tgz",
-      "integrity": "sha512-JdD4s17hwW8XdPf5L0yiSsuNBdBFSqxoP9hCZkxykrIANiXeBiAb2AwyiahhxiOiUdr5vU56djGMq2Yd1ehNrQ==",
-      "requires": {
-        "did-resolver": "1.0.0",
-        "xmlhttprequest": "^1.8.0"
-      },
-      "dependencies": {
-        "did-resolver": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-1.0.0.tgz",
-          "integrity": "sha512-mgJG0oqlkG7jfRzW0yN9qKawp24M4thGFdfIaZI30SAJXhpkkjqbkRxqMZLJNwqXEM0cqFbXaiFDqnd9Q1UUaw=="
-        }
-      }
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -5764,11 +5581,6 @@
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
-    "is-fn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
-      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw="
-    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -5789,11 +5601,6 @@
       "requires": {
         "is-extglob": "^1.0.0"
       }
-    },
-    "is-hex-prefixed": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
     "is-module": {
       "version": "1.0.0",
@@ -7651,22 +7458,6 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
-    "number-to-bn": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        }
-      }
-    },
     "nwsapi": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
@@ -9422,15 +9213,6 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
-    "promise-to-callback": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
-      "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
-      "requires": {
-        "is-fn": "^1.0.0",
-        "set-immediate-shim": "^1.0.1"
-      }
-    },
     "promise.series": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/promise.series/-/promise.series-0.2.0.tgz",
@@ -9803,7 +9585,8 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -11839,11 +11622,6 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
-    },
     "set-value": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
@@ -12799,14 +12577,6 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
-    },
-    "strip-hex-prefix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-      "requires": {
-        "is-hex-prefixed": "1.0.0"
-      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -14078,11 +13848,6 @@
         "async-limiter": "~1.0.0"
       }
     },
-    "xhr2": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.3.tgz",
-      "integrity": "sha1-y/xHWaabSoiOeM9PILBRA4dXvRE="
-    },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -14094,11 +13859,6 @@
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
       "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
       "dev": true
-    },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -84,8 +84,6 @@
     "buffer": "^5.2.1",
     "did-resolver": "^1.0.0",
     "elliptic": "^6.4.0",
-    "ethr-did-resolver": "^1.0.1",
-    "https-did-resolver": "^1.0.0",
     "js-sha256": "^0.9.0",
     "js-sha3": "^0.8.0",
     "tweetnacl": "^1.0.1",

--- a/src/__tests__/JWT-test.ts
+++ b/src/__tests__/JWT-test.ts
@@ -4,7 +4,6 @@ import {
   decodeJWT,
   resolveAuthenticator,
   NBF_SKEW,
-  resolver,
   normalizeDID
 } from '../JWT'
 import { TokenVerifier } from 'jsontokens'
@@ -13,7 +12,6 @@ import NaclSigner from '../NaclSigner'
 import { verifyJWT as naclVerifyJWT } from 'nacl-did'
 import MockDate from 'mockdate'
 
-const originalResolve = resolver.resolve
 const NOW = 1485321133
 MockDate.set(NOW * 1000 + 123)
 
@@ -185,35 +183,31 @@ describe('createJWT()', () => {
 })
 
 describe('verifyJWT()', () => {
-  beforeAll(() => {
-    resolver.resolve = jest.fn().mockReturnValue(didDoc)
-  })
-  afterAll(() => {
-    resolver.resolve = originalResolve
-  })
+  const resolver = { resolve: jest.fn().mockReturnValue(didDoc) }
+
   describe('pregenerated JWT', () => {
     // tslint:disable-next-line: max-line-length
     const incomingJwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsImlzcyI6ImRpZDpldGhyOjB4OTBlNDVkNzViZDEyNDZlMDkyNDg3MjAxODY0N2RiYTk5NmE4ZTdiOSIsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXX0.KIG2zUO8Quf3ucb9jIncZ1CmH0v-fAZlsKvesfsd9x4RzU0qrvinVd9d30DOeZOwdwEdXkET_wuPoOECwU0IKA'
     it('verifies the JWT and return correct payload', async () => {
-      const { payload } = await verifyJWT(incomingJwt)
+      const { payload } = await verifyJWT(incomingJwt, { resolver })
       return expect(payload).toMatchSnapshot()
     })
     it('verifies the JWT and return correct profile', async () => {
-      const { doc } = await verifyJWT(incomingJwt)
+      const { doc } = await verifyJWT(incomingJwt, { resolver })
       return expect(doc).toEqual(didDoc)
     })
     it('verifies the JWT and return correct did for the iss', async () => {
-      const { issuer } = await verifyJWT(incomingJwt)
+      const { issuer } = await verifyJWT(incomingJwt, { resolver })
       return expect(issuer).toEqual(
         'did:ethr:0x90e45d75bd1246e0924872018647dba996a8e7b9'
       )
     })
     it('verifies the JWT and return correct signer', async () => {
-      const { signer } = await verifyJWT(incomingJwt)
+      const { signer } = await verifyJWT(incomingJwt, { resolver })
       return expect(signer).toEqual(didDoc.publicKey[0])
     })
     it('verifies the JWT requiring authentication and return correct signer', async () => {
-      const { signer } = await verifyJWT(incomingJwt, { auth: true })
+      const { signer } = await verifyJWT(incomingJwt, { resolver, auth: true })
       return expect(signer).toEqual(didDoc.publicKey[0])
     })
   })
@@ -222,7 +216,7 @@ describe('verifyJWT()', () => {
     // tslint:disable-next-line: max-line-length
     const badJwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsImlzcyI6ImRpZDpldGhyOjB4MjBjNzY5ZWM5YzA5OTZiYTc3MzdhNDgyNmMyYWFmZjAwYjFiMjA0MCIsInJlcXVlc3RlZCI6WyJuYW1lIiwicGhvbmUiXX0.TTpuw77fUbd_AY3GJcCumd6F6hxnkskMDJYNpJlI2DQi5MKKudXya9NlyM9e8-KFgTLe-WnXgq9EjWLvjpdiXA'
     it('rejects a JWT with bad signature', async () => {
-      expect(verifyJWT(badJwt)).rejects.toThrowError(
+      expect(verifyJWT(badJwt, { resolver })).rejects.toThrowError(
         /Signature invalid for JWT/
       )
     })
@@ -233,43 +227,43 @@ describe('verifyJWT()', () => {
       // tslint:disable-next-line: max-line-length
       const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsIm5iZiI6MTQ4NTI2MTEzMywiaXNzIjoiZGlkOmV0aHI6MHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0In0.FUasGkOYqGVxQ7S-QQvh4abGO6Dwr961UjjOxtRTyUDnl6q6ElqHqAK-WMDTmOir21pFPKLYZMtLZ4LTLpm3cQ'
       // const jwt = await createJWT({nbf: PAST}, {issuer:did, signer})
-      expect(verifyJWT(jwt)).resolves.not.toThrow()
+      expect(verifyJWT(jwt, { resolver })).resolves.not.toThrow()
     })
     it('passes when nbf is in the past and iat is in the future', async () => {
       // tslint:disable-next-line: max-line-length
       const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzODExMzMsIm5iZiI6MTQ4NTI2MTEzMywiaXNzIjoiZGlkOmV0aHI6MHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0In0.8BPiSG2e6UBn1osnJ6PJYbPjtPMPaCeutTA9OCp-ZzI-QvvwPCVrrWqTu2YELbzUPwDIJCQ8v8N77xCEjIYSmQ'
       // const jwt = await createJWT({nbf:PAST,iat:FUTURE},{issuer:did,signer})
-      expect(verifyJWT(jwt)).resolves.not.toThrow()
+      expect(verifyJWT(jwt, { resolver })).resolves.not.toThrow()
     })
     it('fails when nbf is in the future', async () => {
       // tslint:disable-next-line: max-line-length
       const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzMjExMzMsIm5iZiI6MTQ4NTM4MTEzMywiaXNzIjoiZGlkOnVwb3J0OjJuUXRpUUc2Q2dtMUdZVEJhYUtBZ3I3NnVZN2lTZXhVa3FYIn0.rcFuhVHtie3Y09pWxBSf1dnjaVh6FFQLHh-83N-uLty3M5ADJ-jVFFkyt_Eupl8Kr735-oPGn_D1Nj9rl4s_Kw'
       // const jwt = await createJWT({nbf:FUTURE},{issuer:did,signer})
-      expect(verifyJWT(jwt)).rejects.toThrow()
+      expect(verifyJWT(jwt, { resolver })).rejects.toThrow()
     })
     it('fails when nbf is in the future and iat is in the past', async () => {
       // tslint:disable-next-line: max-line-length
       const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUyNjExMzMsIm5iZiI6MTQ4NTM4MTEzMywiaXNzIjoiZGlkOmV0aHI6MHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0In0.JjEn_huxI9SsBY_3PlD0ShpXvrRgUGFDKAgxJBc1Q5GToVpUTw007-o9BTt7JNi_G2XWmcu2aXXnDn0QFsRIrg'
       // const jwt = await createJWT({nbf:FUTURE,iat:PAST},{issuer:did,signer})
-      expect(verifyJWT(jwt)).rejects.toThrow()
+      expect(verifyJWT(jwt, { resolver })).rejects.toThrow()
     })
     it('passes when nbf is missing and iat is in the past', async () => {
       // tslint:disable-next-line: max-line-length
       const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUyNjExMzMsImlzcyI6ImRpZDpldGhyOjB4ZjNiZWFjMzBjNDk4ZDllMjY4NjVmMzRmY2FhNTdkYmI5MzViMGQ3NCJ9.jkzN5kIVtuRU-Fjte8w5r-ttf9OfhdN38oFJd61CWdI5WnvU1dPCvnx1_kdk2D6Xg-uPqp1VXAb7KA2ZECivmg'
       // const jwt = await createJWT({iat:PAST},{issuer:did,signer})
-      expect(verifyJWT(jwt)).resolves.not.toThrow()
+      expect(verifyJWT(jwt, { resolver })).resolves.not.toThrow()
     })
     it('fails when nbf is missing and iat is in the future', async () => {
       // tslint:disable-next-line: max-line-length
       const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE0ODUzODExMzMsImlzcyI6ImRpZDpldGhyOjB4ZjNiZWFjMzBjNDk4ZDllMjY4NjVmMzRmY2FhNTdkYmI5MzViMGQ3NCJ9.FJuHvf9Tby7b4I54Cm1nh8CvLg4QH2wt2K0WfyQaLqlr3NKKI5hAdLalgZksI25gLhNrZwQFnC-nzEOs9PI1SQ'
       // const jwt = await createJWT({iat:FUTURE},{issuer:did,signer})
-      expect(verifyJWT(jwt)).rejects.toThrow()
+      expect(verifyJWT(jwt, { resolver })).rejects.toThrow()
     })
     it('passes when nbf and iat are both missing', async () => {
       // tslint:disable-next-line: max-line-length
       const jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.KgnwgMMz-QSOtpba2QMGHMWJoLvhp-H4odjjX1QKnqj4-8dkcK12y7rj7Zq24-1d-1ne86aJCdWtx5VJv3rM7w'
       // const jwt = await createJWT({iat:undefined},{issuer:did,signer})
-      expect(verifyJWT(jwt)).resolves.not.toThrow()
+      expect(verifyJWT(jwt, { resolver })).resolves.not.toThrow()
     })
   })
 
@@ -278,7 +272,7 @@ describe('verifyJWT()', () => {
       { hello: 'world' },
       { issuer: did, signer, alg: 'ES256K-R' }
     )
-    const { payload } = await verifyJWT(jwt)
+    const { payload } = await verifyJWT(jwt, { resolver })
     return expect(payload).toMatchSnapshot()
   })
 
@@ -287,13 +281,13 @@ describe('verifyJWT()', () => {
       { hello: 'world' },
       { issuer: aud, signer, alg: 'ES256K-R' }
     )
-    const { payload } = await verifyJWT(jwt)
+    const { payload } = await verifyJWT(jwt, { resolver })
     return expect(payload).toMatchSnapshot()
   })
 
   it('accepts a valid exp', async () => {
     const jwt = await createJWT({ exp: NOW }, { issuer: did, signer })
-    const { payload } = await verifyJWT(jwt)
+    const { payload } = await verifyJWT(jwt, { resolver })
     return expect(payload).toBeDefined()
   })
 
@@ -302,14 +296,14 @@ describe('verifyJWT()', () => {
       { exp: NOW - NBF_SKEW - 1 },
       { issuer: did, signer }
     )
-    expect(verifyJWT(jwt))
+    expect(verifyJWT(jwt, { resolver }))
       .rejects
       .toThrow(/JWT has expired/)
   })
 
   it('accepts a valid audience', async () => {
     const jwt = await createJWT({ aud }, { issuer: did, signer })
-    const { payload } = await verifyJWT(jwt, { audience: aud })
+    const { payload } = await verifyJWT(jwt, { resolver, audience: aud })
     return expect(payload).toMatchSnapshot()
   })
 
@@ -319,6 +313,7 @@ describe('verifyJWT()', () => {
       { issuer: did, signer }
     )
     const { payload } = await verifyJWT(jwt, {
+      resolver,
       callbackUrl: 'http://pututu.uport.me/unique'
     })
     return expect(payload).toMatchSnapshot()
@@ -326,7 +321,7 @@ describe('verifyJWT()', () => {
 
   it('rejects invalid audience', async () => {
     const jwt = await createJWT({ aud }, { issuer: did, signer })
-    expect(verifyJWT(jwt, { audience: did }))
+    expect(verifyJWT(jwt, { resolver, audience: did }))
       .rejects
       .toThrow(/JWT audience does not match your DID/)
   })
@@ -336,7 +331,7 @@ describe('verifyJWT()', () => {
       { aud: 'http://pututu.uport.me/unique' },
       { issuer: did, signer }
     )
-    expect(verifyJWT(jwt, { callbackUrl: 'http://pututu.uport.me/unique/1' }))
+    expect(verifyJWT(jwt, { resolver, callbackUrl: 'http://pututu.uport.me/unique/1' }))
       .rejects
       .toThrow(/JWT audience does not match the callback url/)
   })
@@ -346,14 +341,14 @@ describe('verifyJWT()', () => {
       { aud: 'http://pututu.uport.me/unique' },
       { issuer: did, signer }
     )
-    expect(verifyJWT(jwt))
+    expect(verifyJWT(jwt, { resolver }))
       .rejects
       .toThrow('JWT audience matching your callback url is required but one wasn\'t passed in')
   })
 
   it('rejects invalid audience as no address is present', async () => {
     const jwt = await createJWT({ aud }, { issuer: did, signer })
-    expect(verifyJWT(jwt))
+    expect(verifyJWT(jwt, { resolver }))
       .rejects
       .toThrow('JWT audience is required but your app address has not been configured')
   })
@@ -444,14 +439,9 @@ describe('resolveAuthenticator()', () => {
   }
 
   describe('DID', () => {
-    afterEach(() => {
-      resolver.resolve = originalResolve
-    })
-
     describe('ES256K', () => {
       it('finds public key', async () => {
-        resolver.resolve = jest.fn().mockReturnValue(singleKey)
-        const authenticators = await resolveAuthenticator(alg, did)
+        const authenticators = await resolveAuthenticator({ resolve: jest.fn().mockReturnValue(singleKey) }, alg, did)
         return expect(authenticators).toEqual({
           authenticators: [ecKey1],
           issuer: did,
@@ -460,8 +450,7 @@ describe('resolveAuthenticator()', () => {
       })
 
       it('filters out irrelevant public keys', async () => {
-        resolver.resolve = jest.fn().mockReturnValue(multipleKeys)
-        const authenticators = await resolveAuthenticator(alg, did)
+        const authenticators = await resolveAuthenticator({ resolve: jest.fn().mockReturnValue(multipleKeys) }, alg, did)
         return expect(authenticators).toEqual({
           authenticators: [ecKey1, ecKey2, ecKey3],
           issuer: did,
@@ -470,8 +459,7 @@ describe('resolveAuthenticator()', () => {
       })
 
       it('only list authenticators able to authenticate a user', async () => {
-        resolver.resolve = jest.fn().mockReturnValue(multipleKeys)
-        const authenticators = await resolveAuthenticator(alg, did, true)
+        const authenticators = await resolveAuthenticator({ resolve: jest.fn().mockReturnValue(multipleKeys) }, alg, did, true)
         return expect(authenticators).toEqual({
           authenticators: [ecKey1, ecKey2],
           issuer: did,
@@ -480,8 +468,7 @@ describe('resolveAuthenticator()', () => {
       })
 
       it('errors if no suitable public keys exist', async () => {
-        resolver.resolve = jest.fn().mockReturnValue(unsupportedFormat)
-        return expect(resolveAuthenticator(alg, did)).rejects.toEqual(
+        return expect(resolveAuthenticator({ resolve: jest.fn().mockReturnValue(unsupportedFormat) }, alg, did)).rejects.toEqual(
           new Error(
             `DID document for ${did} does not have public keys for ${alg}`
           )
@@ -492,8 +479,7 @@ describe('resolveAuthenticator()', () => {
     describe('Ed25519', () => {
       const alg = 'Ed25519'
       it('filters out irrelevant public keys', async () => {
-        resolver.resolve = jest.fn().mockReturnValue(multipleKeys)
-        const authenticators = await resolveAuthenticator(alg, did)
+        const authenticators = await resolveAuthenticator({ resolve: jest.fn().mockReturnValue(multipleKeys) }, alg, did)
         return expect(authenticators).toEqual({
           authenticators: [edKey, edKey2],
           issuer: did,
@@ -502,8 +488,7 @@ describe('resolveAuthenticator()', () => {
       })
 
       it('only list authenticators able to authenticate a user', async () => {
-        resolver.resolve = jest.fn().mockReturnValue(multipleKeys)
-        const authenticators = await resolveAuthenticator(alg, did, true)
+        const authenticators = await resolveAuthenticator({ resolve: jest.fn().mockReturnValue(multipleKeys) }, alg, did, true)
         return expect(authenticators).toEqual({
           authenticators: [edKey],
           issuer: did,
@@ -512,8 +497,7 @@ describe('resolveAuthenticator()', () => {
       })
 
       it('errors if no suitable public keys exist', async () => {
-        resolver.resolve = jest.fn().mockReturnValue(unsupportedFormat)
-        return expect(resolveAuthenticator(alg, did)).rejects.toEqual(
+        return expect(resolveAuthenticator({ resolve: jest.fn().mockReturnValue(unsupportedFormat) }, alg, did)).rejects.toEqual(
           new Error(
             `DID document for ${did} does not have public keys for ${alg}`
           )
@@ -522,8 +506,7 @@ describe('resolveAuthenticator()', () => {
     })
 
     it('errors if no suitable public keys exist for authentication', async () => {
-      resolver.resolve = jest.fn().mockReturnValue(singleKey)
-      return expect(resolveAuthenticator(alg, did, true)).rejects.toEqual(
+      return expect(resolveAuthenticator({ resolve: jest.fn().mockReturnValue(singleKey) }, alg, did, true)).rejects.toEqual(
         new Error(
           `DID document for ${did} does not have public keys suitable for authenticationg user`
         )
@@ -531,8 +514,7 @@ describe('resolveAuthenticator()', () => {
     })
 
     it('errors if no public keys exist', async () => {
-      resolver.resolve = jest.fn().mockReturnValue(noPublicKey)
-      return expect(resolveAuthenticator(alg, did)).rejects.toEqual(
+      return expect(resolveAuthenticator({ resolve: jest.fn().mockReturnValue(noPublicKey) }, alg, did)).rejects.toEqual(
         new Error(
           `DID document for ${did} does not have public keys for ${alg}`
         )
@@ -540,15 +522,13 @@ describe('resolveAuthenticator()', () => {
     })
 
     it('errors if no DID document exists', async () => {
-      resolver.resolve = jest.fn().mockReturnValue(null)
-      return expect(resolveAuthenticator(alg, did)).rejects.toEqual(
+      return expect(resolveAuthenticator({ resolve: jest.fn().mockReturnValue(null) }, alg, did)).rejects.toEqual(
         new Error(`Unable to resolve DID document for ${did}`)
       )
     })
 
     it('errors if no supported signature types exist', async () => {
-      resolver.resolve = jest.fn().mockReturnValue(singleKey)
-      return expect(resolveAuthenticator('ESBAD', did)).rejects.toEqual(
+      return expect(resolveAuthenticator({ resolve: jest.fn().mockReturnValue(singleKey) }, 'ESBAD', did)).rejects.toEqual(
         new Error(`No supported signature types for algorithm ESBAD`)
       )
     })


### PR DESCRIPTION
BREAKING CHANGE: verifyJWT now requires the user to provide a did-resolver. This allows the user to configure their own resolver instead of being limited to default ethr-did and https-did resolvers